### PR TITLE
Change field type in photo for ImageField

### DIFF
--- a/AmbieNet/posts/models/posts.py
+++ b/AmbieNet/posts/models/posts.py
@@ -23,7 +23,7 @@ class Post(AmbieNetModel):
     #"likes"
     validator_number = models.IntegerField(default=0)
 
-    photo=models.CharField(max_length=255, blank=True)
+    photo=models.ImageField(max_length=255, blank=True)
 
     username = models.CharField(max_length=255, blank=True)
 


### PR DESCRIPTION
## :loudspeaker: Tipo de cambio
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] Nueva característica
- [x] Mejoras
- [ ] Refactorización


## :scroll: Descripción
<!--- Describe your changes in detail -->
Se cambio el tipo de campo de CharField a ImageField en el campo photo de post con el objetivo de renderizar las imagenes en django y no en PHP como se hace ahora :D
### Notas
Es solo la parte inicial, falta renderizar la imagen con los serializer, no se como hacer eso :c
## :bulb: Motivación y Contexto
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Renderizar las imagenes desde Django
Ticket []() 

## :green_heart: ¿Cómo se hicieron pruebas?
Null